### PR TITLE
Migrate DB primary key to (username, hash)

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -131,7 +131,7 @@ func (db *DB) Add(ctx context.Context, content Content) (err error) {
 	result, err := db.Exec(ctx, `
 		INSERT INTO content (username, hash, name, size)
 		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (username, hash) DO NOTHING
+		ON CONFLICT (hash) DO NOTHING
 	`, content.User, content.Hash, content.Name, content.Size)
 	if err != nil {
 		return Error.Wrap(err)

--- a/proxy/add_test.go
+++ b/proxy/add_test.go
@@ -89,52 +89,46 @@ func TestAddHandler(t *testing.T) {
 		err = addFile(proxy.URL, "shawn", "first.jpg", 1024)
 		require.NoError(t, err)
 
-		// Check that both users has the same file
+		// Check that nothing changed in the DB, the file is still mapped to the first user
 		contents, err = db.List(ctx)
-		sortByCreated(contents)
 		require.NoError(t, err)
-		require.Len(t, contents, 2)
+		require.Len(t, contents, 1)
 		assert.Equal(t, content1, contents[0])
-		assert.Equal(t, "shawn", contents[1].User)
-		assert.Equal(t, content1.Name, contents[1].Name)
-		assert.Equal(t, content1.Size, contents[1].Size)
 
 		// Upload a different file with the second user
 		err = addFile(proxy.URL, "shawn", "second.jpg", 1234)
 		require.NoError(t, err)
 
-		// Check that the first user has one file, and the second - two files
+		// Check that both users have one file each
 		contents, err = db.List(ctx)
 		sortByCreated(contents)
 		require.NoError(t, err)
-		require.Len(t, contents, 3)
-		assert.Equal(t, content1, contents[0])
+		require.Len(t, contents, 2)
+		assert.Equal(t, "john", contents[0].User)
+		assert.Equal(t, "first.jpg", contents[0].Name)
+		assert.Equal(t, int64(1024), contents[0].Size)
 		assert.Equal(t, "shawn", contents[1].User)
-		assert.Equal(t, content1.Name, contents[1].Name)
-		assert.Equal(t, content1.Size, contents[1].Size)
-		assert.Equal(t, "shawn", contents[2].User)
-		assert.Equal(t, "second.jpg", contents[2].Name)
-		assert.Equal(t, int64(1234), contents[2].Size)
+		assert.Equal(t, "second.jpg", contents[1].Name)
+		assert.Equal(t, int64(1234), contents[1].Size)
 
 		// Upload a third file with the first user
 		err = addFile(proxy.URL, "john", "third.jpg", 12987)
 		require.NoError(t, err)
 
-		// Check that both users have two files
+		// Check that both first user has two file, and the second user - one file
 		contents, err = db.List(ctx)
 		sortByCreated(contents)
 		require.NoError(t, err)
-		require.Len(t, contents, 4)
-		assert.Equal(t, content1, contents[0])
+		require.Len(t, contents, 3)
+		assert.Equal(t, "john", contents[0].User)
+		assert.Equal(t, "first.jpg", contents[0].Name)
+		assert.Equal(t, int64(1024), contents[0].Size)
 		assert.Equal(t, "shawn", contents[1].User)
-		assert.Equal(t, content1.Name, contents[1].Name)
-		assert.Equal(t, content1.Size, contents[1].Size)
-		assert.Equal(t, "shawn", contents[2].User)
-		assert.Equal(t, "second.jpg", contents[2].Name)
-		assert.Equal(t, int64(1234), contents[2].Size)
-		assert.Equal(t, "john", contents[3].User)
-		assert.Equal(t, "third.jpg", contents[3].Name)
-		assert.Equal(t, int64(12987), contents[3].Size)
+		assert.Equal(t, "second.jpg", contents[1].Name)
+		assert.Equal(t, int64(1234), contents[1].Size)
+		assert.Equal(t, "john", contents[2].User)
+		assert.Equal(t, "third.jpg", contents[2].Name)
+		assert.Equal(t, int64(12987), contents[2].Size)
 	})
 }
 

--- a/proxy/add_test.go
+++ b/proxy/add_test.go
@@ -88,44 +88,49 @@ func TestAddHandler(t *testing.T) {
 		err = addFile(proxy.URL, "shawn", "first.jpg", 1024)
 		require.NoError(t, err)
 
-		// Check that nothing changed in the DB, the file is still mapped to the first user
+		// Check that both users has the same file
 		contents, err = db.List(ctx)
 		require.NoError(t, err)
-		require.Len(t, contents, 1)
+		require.Len(t, contents, 2)
 		assert.Equal(t, content1, contents[0])
+		assert.Equal(t, "shawn", contents[1].User)
+		assert.Equal(t, content1.Name, contents[1].Name)
+		assert.Equal(t, content1.Size, contents[1].Size)
 
 		// Upload a different file with the second user
 		err = addFile(proxy.URL, "shawn", "second.jpg", 1234)
 		require.NoError(t, err)
 
-		// Check that both users have one file each
+		// Check that the first user has one file, and the second - two files
 		contents, err = db.List(ctx)
 		require.NoError(t, err)
-		require.Len(t, contents, 2)
-		assert.Equal(t, "john", contents[0].User)
-		assert.Equal(t, "first.jpg", contents[0].Name)
-		assert.Equal(t, int64(1024), contents[0].Size)
+		require.Len(t, contents, 3)
+		assert.Equal(t, content1, contents[0])
 		assert.Equal(t, "shawn", contents[1].User)
-		assert.Equal(t, "second.jpg", contents[1].Name)
-		assert.Equal(t, int64(1234), contents[1].Size)
+		assert.Equal(t, content1.Name, contents[1].Name)
+		assert.Equal(t, content1.Size, contents[1].Size)
+		assert.Equal(t, "shawn", contents[2].User)
+		assert.Equal(t, "second.jpg", contents[2].Name)
+		assert.Equal(t, int64(1234), contents[2].Size)
 
 		// Upload a third file with the first user
 		err = addFile(proxy.URL, "john", "third.jpg", 12987)
 		require.NoError(t, err)
 
-		// Check that both first user has two file, and the second user - one file
+		// Check that both users have two files
 		contents, err = db.List(ctx)
 		require.NoError(t, err)
-		require.Len(t, contents, 3)
-		assert.Equal(t, "john", contents[0].User)
-		assert.Equal(t, "first.jpg", contents[0].Name)
-		assert.Equal(t, int64(1024), contents[0].Size)
+		require.Len(t, contents, 4)
+		assert.Equal(t, content1, contents[0])
 		assert.Equal(t, "shawn", contents[1].User)
-		assert.Equal(t, "second.jpg", contents[1].Name)
-		assert.Equal(t, int64(1234), contents[1].Size)
-		assert.Equal(t, "john", contents[2].User)
-		assert.Equal(t, "third.jpg", contents[2].Name)
-		assert.Equal(t, int64(12987), contents[2].Size)
+		assert.Equal(t, content1.Name, contents[1].Name)
+		assert.Equal(t, content1.Size, contents[1].Size)
+		assert.Equal(t, "shawn", contents[2].User)
+		assert.Equal(t, "second.jpg", contents[2].Name)
+		assert.Equal(t, int64(1234), contents[2].Size)
+		assert.Equal(t, "john", contents[3].User)
+		assert.Equal(t, "third.jpg", contents[3].Name)
+		assert.Equal(t, int64(12987), contents[3].Size)
 	})
 }
 

--- a/proxy/add_test.go
+++ b/proxy/add_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -90,6 +91,7 @@ func TestAddHandler(t *testing.T) {
 
 		// Check that both users has the same file
 		contents, err = db.List(ctx)
+		sortByCreated(contents)
 		require.NoError(t, err)
 		require.Len(t, contents, 2)
 		assert.Equal(t, content1, contents[0])
@@ -103,6 +105,7 @@ func TestAddHandler(t *testing.T) {
 
 		// Check that the first user has one file, and the second - two files
 		contents, err = db.List(ctx)
+		sortByCreated(contents)
 		require.NoError(t, err)
 		require.Len(t, contents, 3)
 		assert.Equal(t, content1, contents[0])
@@ -119,6 +122,7 @@ func TestAddHandler(t *testing.T) {
 
 		// Check that both users have two files
 		contents, err = db.List(ctx)
+		sortByCreated(contents)
 		require.NoError(t, err)
 		require.Len(t, contents, 4)
 		assert.Equal(t, content1, contents[0])
@@ -184,6 +188,12 @@ func addRequest(url, user, fileName string, fileSize int) (*http.Request, error)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
 	return req, nil
+}
+
+func sortByCreated(contents []db.Content) {
+	sort.Slice(contents, func(i, j int) bool {
+		return contents[i].Created.Before(contents[j].Created)
+	})
 }
 
 func runTest(t *testing.T, mockHandler func(http.ResponseWriter, *http.Request), f func(*testing.T, context.Context, *httptest.Server, *db.DB)) {


### PR DESCRIPTION
It would allow us to track multiple users pinning the same IPFS hash.

This is the first of a two-step migration.