### PR TITLE
Drop obsolete unique constraint on hash column

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"storj.io/private/dbutil"
-	_ "storj.io/private/dbutil/cockroachutil" // registers cockroach as a tagsql driver.
+	"storj.io/private/dbutil/cockroachutil" // registers cockroach as a tagsql driver.
 	"storj.io/private/migrate"
 	"storj.io/private/tagsql"
 )
@@ -118,6 +118,30 @@ func (db *DB) Migration() *migrate.Migration {
 					`ALTER TABLE content DROP COLUMN id`,
 				},
 			},
+			{
+				DB:          &db.DB,
+				Description: "Drop the obsolete unique constraint on the hash column.",
+				Version:     3,
+				Action: migrate.Func(func(ctx context.Context, log *zap.Logger, db tagsql.DB, tx tagsql.Tx) error {
+					if _, ok := db.Driver().(*cockroachutil.Driver); ok {
+						_, err := db.Exec(ctx,
+							`DROP INDEX content_hash_key CASCADE`,
+						)
+						if err != nil {
+							return Error.Wrap(err)
+						}
+						return nil
+					}
+
+					_, err := db.Exec(ctx,
+						`ALTER TABLE content DROP CONSTRAINT content_hash_key`,
+					)
+					if err != nil {
+						return Error.Wrap(err)
+					}
+					return nil
+				}),
+			},
 		},
 	}
 }
@@ -131,7 +155,7 @@ func (db *DB) Add(ctx context.Context, content Content) (err error) {
 	result, err := db.Exec(ctx, `
 		INSERT INTO content (username, hash, name, size)
 		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (hash) DO NOTHING
+		ON CONFLICT (username, hash) DO NOTHING
 	`, content.User, content.Hash, content.Name, content.Size)
 	if err != nil {
 		return Error.Wrap(err)

--- a/proxy/add_test.go
+++ b/proxy/add_test.go
@@ -89,7 +89,7 @@ func TestAddHandler(t *testing.T) {
 		err = addFile(proxy.URL, "shawn", "first.jpg", 1024)
 		require.NoError(t, err)
 
-		// Check that both users has the same file
+		// Check that both users have the same file
 		contents, err = db.List(ctx)
 		require.NoError(t, err)
 		require.Len(t, contents, 2)

--- a/proxy/add_test.go
+++ b/proxy/add_test.go
@@ -89,46 +89,51 @@ func TestAddHandler(t *testing.T) {
 		err = addFile(proxy.URL, "shawn", "first.jpg", 1024)
 		require.NoError(t, err)
 
-		// Check that nothing changed in the DB, the file is still mapped to the first user
+		// Check that both users has the same file
 		contents, err = db.List(ctx)
 		require.NoError(t, err)
-		require.Len(t, contents, 1)
+		require.Len(t, contents, 2)
 		assert.Equal(t, content1, contents[0])
+		assert.Equal(t, "shawn", contents[1].User)
+		assert.Equal(t, content1.Name, contents[1].Name)
+		assert.Equal(t, content1.Size, contents[1].Size)
 
 		// Upload a different file with the second user
 		err = addFile(proxy.URL, "shawn", "second.jpg", 1234)
 		require.NoError(t, err)
 
-		// Check that both users have one file each
+		// Check that the first user has one file, and the second - two files
 		contents, err = db.List(ctx)
 		sortByCreated(contents)
 		require.NoError(t, err)
-		require.Len(t, contents, 2)
-		assert.Equal(t, "john", contents[0].User)
-		assert.Equal(t, "first.jpg", contents[0].Name)
-		assert.Equal(t, int64(1024), contents[0].Size)
+		require.Len(t, contents, 3)
+		assert.Equal(t, content1, contents[0])
 		assert.Equal(t, "shawn", contents[1].User)
-		assert.Equal(t, "second.jpg", contents[1].Name)
-		assert.Equal(t, int64(1234), contents[1].Size)
+		assert.Equal(t, content1.Name, contents[1].Name)
+		assert.Equal(t, content1.Size, contents[1].Size)
+		assert.Equal(t, "shawn", contents[2].User)
+		assert.Equal(t, "second.jpg", contents[2].Name)
+		assert.Equal(t, int64(1234), contents[2].Size)
 
 		// Upload a third file with the first user
 		err = addFile(proxy.URL, "john", "third.jpg", 12987)
 		require.NoError(t, err)
 
-		// Check that both first user has two file, and the second user - one file
+		// Check that both users have two files
 		contents, err = db.List(ctx)
 		sortByCreated(contents)
 		require.NoError(t, err)
-		require.Len(t, contents, 3)
-		assert.Equal(t, "john", contents[0].User)
-		assert.Equal(t, "first.jpg", contents[0].Name)
-		assert.Equal(t, int64(1024), contents[0].Size)
+		require.Len(t, contents, 4)
+		assert.Equal(t, content1, contents[0])
 		assert.Equal(t, "shawn", contents[1].User)
-		assert.Equal(t, "second.jpg", contents[1].Name)
-		assert.Equal(t, int64(1234), contents[1].Size)
-		assert.Equal(t, "john", contents[2].User)
-		assert.Equal(t, "third.jpg", contents[2].Name)
-		assert.Equal(t, int64(12987), contents[2].Size)
+		assert.Equal(t, content1.Name, contents[1].Name)
+		assert.Equal(t, content1.Size, contents[1].Size)
+		assert.Equal(t, "shawn", contents[2].User)
+		assert.Equal(t, "second.jpg", contents[2].Name)
+		assert.Equal(t, int64(1234), contents[2].Size)
+		assert.Equal(t, "john", contents[3].User)
+		assert.Equal(t, "third.jpg", contents[3].Name)
+		assert.Equal(t, int64(12987), contents[3].Size)
 	})
 }
 


### PR DESCRIPTION
This is the second part of the migration, started with #10.